### PR TITLE
Bump snowflake-sdk to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "snowflake-sdk": "^1.5.3"
+    "snowflake-sdk": "^1.6.0"
   }
 }


### PR DESCRIPTION
This PR is to bump snowflake-sdk to 1.6.0.

1.6.0 comes with new authenticator methods and supports External Browser SSO, Key Pair and OAuth to connect to snowflake.

Can you please bump the snowflake-sdk version and release a new package to npm? This package is great, used in [sqltools-snowflake-driver](https://github.com/koszti/sqltools-snowflake-driver) and the bump would allow the SQL client to use further authentication methods to snowflake.