### PR TITLE
expose method to check whether connection is up

### DIFF
--- a/src/Snowflake.ts
+++ b/src/Snowflake.ts
@@ -6,7 +6,7 @@ import { ExecuteOptions } from './types/ExecuteOptions';
 import { LoggingOptions } from './types/LoggingOptions';
 
 export class Snowflake {
-  private readonly sdk_connection;
+  private readonly sdk_connection: SDK.Connection;
   private readonly logSql: (sqlText: string) => void;
 
   /**
@@ -99,5 +99,10 @@ export class Snowflake {
     const stmt = this.createStatement({ sqlText, binds });
     stmt.execute();
     return stmt.getRows();
+  }
+
+  /** Wrapper to expose whether connection to sdk is up */
+  isUp() {
+    return this.sdk_connection.isUp();
   }
 }


### PR DESCRIPTION
When using `snowflake-promise` with a pool of connections, it is important to validate that the connection is still up. This is provided from the `snowflake-sdk` via the `isUp` method. This pull request is to expose the method without exposing the entire `sdk_connection`, which remains private to the class.